### PR TITLE
- Be sure to pass on the transaction options to clearStack

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
@@ -227,7 +227,7 @@ public class FragNavController {
 
         //If our popDepth is big enough that it would just clear the stack, then call that.
         if (popDepth >= mFragmentStacks.get(mSelectedTabIndex).size() - 1) {
-            clearStack();
+            clearStack(transactionOptions);
             return;
         }
 


### PR DESCRIPTION
This small fix ensures that the transaction options sent to the method are passed down to clearStack so that any intended animations will play when the last fragment on a stack is popped.