### PR TITLE
Popping can also cause back navigation between tabs when current stack is depleted

### DIFF
--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.java
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.java
@@ -7,6 +7,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import com.ncapdevi.fragnav.FragNavController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+import com.ncapdevi.fragnav.tabhistory.FragNavTabHistoryController;
 import com.ncapdevi.sample.R;
 import com.ncapdevi.sample.fragments.BaseFragment;
 import com.ncapdevi.sample.fragments.FavoritesFragment;
@@ -32,15 +35,25 @@ public class BottomTabsActivity extends AppCompatActivity implements BaseFragmen
         super.onCreate(savedInstanceState);
         setContentView(com.ncapdevi.sample.R.layout.activity_bottom_tabs);
 
-        BottomBar mBottomBar = findViewById(R.id.bottomBar);
-        mBottomBar.selectTabAtPosition(INDEX_NEARBY);
+        final BottomBar bottomBar = findViewById(R.id.bottomBar);
+        boolean initial = savedInstanceState == null;
+        if (initial) {
+            bottomBar.selectTabAtPosition(INDEX_NEARBY);
+        }
         mNavController = FragNavController.newBuilder(savedInstanceState, getSupportFragmentManager(), R.id.container)
                 .transactionListener(this)
                 .rootFragmentListener(this, 5)
+                .popStrategy(FragNavTabHistoryController.UNIQUE_TAB_HISTORY)
+                .switchController(new FragNavSwitchController() {
+                    @Override
+                    public void switchTab(int index, FragNavTransactionOptions transactionOptions) {
+                        bottomBar.selectTabAtPosition(index);
+                    }
+                })
                 .build();
 
 
-        mBottomBar.setOnTabSelectListener(new OnTabSelectListener() {
+        bottomBar.setOnTabSelectListener(new OnTabSelectListener() {
             @Override
             public void onTabSelected(@IdRes int tabId) {
                 switch (tabId) {
@@ -61,9 +74,9 @@ public class BottomTabsActivity extends AppCompatActivity implements BaseFragmen
                         break;
                 }
             }
-        });
+        }, initial);
 
-        mBottomBar.setOnTabReselectListener(new OnTabReselectListener() {
+        bottomBar.setOnTabReselectListener(new OnTabReselectListener() {
             @Override
             public void onTabReSelected(@IdRes int tabId) {
                 mNavController.clearStack();
@@ -74,9 +87,7 @@ public class BottomTabsActivity extends AppCompatActivity implements BaseFragmen
 
     @Override
     public void onBackPressed() {
-        if (!mNavController.isRootFragment()) {
-            mNavController.popFragment();
-        } else {
+        if (!mNavController.popFragment()) {
             super.onBackPressed();
         }
     }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
@@ -270,7 +270,7 @@ public class FragNavController {
         return mFragNavTabHistoryController.popFragments(popDepth, transactionOptions);
     }
 
-    private int popFragmentsFromCurrentStack(int popDepth, @Nullable FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
+    private int tryPopFragmentsFromCurrentStack(int popDepth, @Nullable FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
         if (mPopStrategy == CURRENT_TAB && isRootFragment()) {
             throw new UnsupportedOperationException(
                     "You can not popFragment the rootFragment. If you need to change this fragment, use replaceFragment(fragment)");
@@ -994,8 +994,8 @@ public class FragNavController {
 
     public class DefaultFragNavPopController implements com.ncapdevi.fragnav.FragNavPopController {
         @Override
-        public int popFragments(int popDepth, FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
-            return FragNavController.this.popFragmentsFromCurrentStack(popDepth, transactionOptions);
+        public int tryPopFragments(int popDepth, FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
+            return FragNavController.this.tryPopFragmentsFromCurrentStack(popDepth, transactionOptions);
         }
     }
 

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.java
@@ -1,0 +1,5 @@
+package com.ncapdevi.fragnav;
+
+public interface FragNavPopController {
+    int popFragments(int popDepth, FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException;
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.java
@@ -1,5 +1,5 @@
 package com.ncapdevi.fragnav;
 
 public interface FragNavPopController {
-    int popFragments(int popDepth, FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException;
+    int tryPopFragments(int popDepth, FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException;
 }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavSwitchController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavSwitchController.java
@@ -1,0 +1,5 @@
+package com.ncapdevi.fragnav;
+
+public interface FragNavSwitchController {
+    void switchTab(@FragNavController.TabIndex int index, FragNavTransactionOptions transactionOptions);
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/BaseFragNavTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/BaseFragNavTabHistoryController.java
@@ -1,0 +1,11 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+
+abstract class BaseFragNavTabHistoryController implements FragNavTabHistoryController {
+    FragNavPopController fragNavPopController;
+
+    BaseFragNavTabHistoryController(FragNavPopController fragNavPopController) {
+        this.fragNavPopController = fragNavPopController;
+    }
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.java
@@ -1,0 +1,73 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+import java.util.ArrayList;
+
+abstract class CollectionFragNavTabHistoryController extends BaseFragNavTabHistoryController {
+    private static final String EXTRA_STACK_HISTORY = "EXTRA_STACK_HISTORY";
+
+    private FragNavSwitchController fragNavSwitchController;
+
+    CollectionFragNavTabHistoryController(FragNavPopController fragNavPopController,
+                                          FragNavSwitchController fragNavSwitchController) {
+        super(fragNavPopController);
+        this.fragNavSwitchController = fragNavSwitchController;
+    }
+
+    @Override
+    public boolean popFragments(int popDepth,
+                                FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
+        boolean changed = false;
+        boolean switched;
+        do {
+            switched = false;
+            int count = fragNavPopController.popFragments(popDepth, transactionOptions);
+            if (count > 0) {
+                changed = true;
+                popDepth -= count;
+            } else if (getCollectionSize() > 1) {
+                fragNavSwitchController.switchTab(getAndRemoveIndex(), transactionOptions);
+                popDepth--;
+                changed = true;
+                switched = true;
+            }
+        } while (popDepth > 0 && switched);
+        return changed;
+    }
+
+    abstract int getCollectionSize();
+
+    abstract int getAndRemoveIndex();
+
+    @NonNull
+    abstract ArrayList<Integer> getHistory();
+
+    abstract void setHistory(@NonNull ArrayList<Integer> history);
+
+    @Override
+    public void restoreFromBundle(@Nullable Bundle savedInstanceState) {
+        if (savedInstanceState == null) {
+            return;
+        }
+        ArrayList<Integer> arrayList = savedInstanceState.getIntegerArrayList(EXTRA_STACK_HISTORY);
+        if (arrayList != null) {
+            setHistory(arrayList);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        ArrayList<Integer> history = getHistory();
+        if (history.isEmpty()) {
+            return;
+        }
+        outState.putIntegerArrayList(EXTRA_STACK_HISTORY, history);
+    }
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.java
@@ -28,9 +28,10 @@ abstract class CollectionFragNavTabHistoryController extends BaseFragNavTabHisto
         boolean switched;
         do {
             switched = false;
-            int count = fragNavPopController.popFragments(popDepth, transactionOptions);
+            int count = fragNavPopController.tryPopFragments(popDepth, transactionOptions);
             if (count > 0) {
                 changed = true;
+                switched = true;
                 popDepth -= count;
             } else if (getCollectionSize() > 1) {
                 fragNavSwitchController.switchTab(getAndRemoveIndex(), transactionOptions);

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.ncapdevi.fragnav.FragNavPopController;
-import com.ncapdevi.fragnav.FragNavSwitchController;
 import com.ncapdevi.fragnav.FragNavTransactionOptions;
 
 public class CurrentTabHistoryController extends BaseFragNavTabHistoryController {
@@ -16,7 +15,7 @@ public class CurrentTabHistoryController extends BaseFragNavTabHistoryController
     @Override
     public boolean popFragments(int popDepth,
                                 FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
-        return fragNavPopController.popFragments(popDepth, transactionOptions) > 0;
+        return fragNavPopController.tryPopFragments(popDepth, transactionOptions) > 0;
     }
 
     @Override

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.java
@@ -1,0 +1,33 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+public class CurrentTabHistoryController extends BaseFragNavTabHistoryController {
+    public CurrentTabHistoryController(FragNavPopController fragNavPopController) {
+        super(fragNavPopController);
+    }
+
+    @Override
+    public boolean popFragments(int popDepth,
+                                FragNavTransactionOptions transactionOptions) throws UnsupportedOperationException {
+        return fragNavPopController.popFragments(popDepth, transactionOptions) > 0;
+    }
+
+    @Override
+    public void switchTab(int index) {
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+    }
+
+    @Override
+    public void restoreFromBundle(@Nullable Bundle savedInstanceState) {
+    }
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.java
@@ -1,0 +1,45 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.os.Bundle;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+public interface FragNavTabHistoryController {
+    /**
+     * Define what happens when we try to pop on a tab where root fragment is at the top
+     */
+    @Retention(SOURCE)
+    @IntDef({CURRENT_TAB, UNIQUE_TAB_HISTORY, UNLIMITED_TAB_HISTORY})
+    @interface PopStrategy {
+    }
+
+    /**
+     * We only pop fragments from current tab, don't switch between tabs
+     */
+    int CURRENT_TAB = 0;
+
+    /**
+     * We keep a history of tabs (each tab is present only once) and we switch to previous tab in history when we pop on root fragment
+     */
+    int UNIQUE_TAB_HISTORY = 1;
+
+    /**
+     * We keep an uncapped history of tabs and we switch to previous tab in history when we pop on root fragment
+     */
+    int UNLIMITED_TAB_HISTORY = 2;
+
+    boolean popFragments(int popDepth, FragNavTransactionOptions transactionOptions);
+
+    void switchTab(int index);
+
+    void onSaveInstanceState(@NonNull Bundle outState);
+
+    void restoreFromBundle(@Nullable Bundle savedInstanceState);
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryController.java
@@ -1,0 +1,52 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.support.annotation.NonNull;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class UniqueTabHistoryController extends CollectionFragNavTabHistoryController {
+    private Set<Integer> tabHistory = new LinkedHashSet<>();
+
+    public UniqueTabHistoryController(FragNavPopController fragNavPopController,
+                                      FragNavSwitchController fragNavSwitchController) {
+        super(fragNavPopController, fragNavSwitchController);
+    }
+
+    @Override
+    int getCollectionSize() {
+        return tabHistory.size();
+    }
+
+    @Override
+    int getAndRemoveIndex() {
+        ArrayList<Integer> tabList = getHistory();
+        int currentPage = tabList.get(tabHistory.size() - 1);
+        int targetPage = tabList.get(tabHistory.size() - 2);
+        tabHistory.remove(currentPage);
+        tabHistory.remove(targetPage);
+        return targetPage;
+    }
+
+    @Override
+    public void switchTab(int index) {
+        tabHistory.remove(index);
+        tabHistory.add(index);
+    }
+
+    @NonNull
+    @Override
+    ArrayList<Integer> getHistory() {
+        return new ArrayList<>(tabHistory);
+    }
+
+    @Override
+    void setHistory(@NonNull ArrayList<Integer> history) {
+        tabHistory.clear();
+        tabHistory.addAll(history);
+    }
+}

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryController.java
@@ -1,0 +1,46 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.support.annotation.NonNull;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+
+import java.util.ArrayList;
+import java.util.Stack;
+
+public class UnlimitedTabHistoryController extends CollectionFragNavTabHistoryController {
+    private Stack<Integer> tabHistory = new Stack<>();
+
+    public UnlimitedTabHistoryController(FragNavPopController fragNavPopController,
+                                         FragNavSwitchController fragNavSwitchController) {
+        super(fragNavPopController, fragNavSwitchController);
+    }
+
+    @Override
+    int getCollectionSize() {
+        return tabHistory.size();
+    }
+
+    @Override
+    int getAndRemoveIndex() {
+        tabHistory.pop();
+        return tabHistory.pop();
+    }
+
+    @Override
+    public void switchTab(int index) {
+        tabHistory.push(index);
+    }
+
+    @NonNull
+    @Override
+    ArrayList<Integer> getHistory() {
+        return new ArrayList<>(tabHistory);
+    }
+
+    @Override
+    void setHistory(@NonNull ArrayList<Integer> history) {
+        tabHistory.clear();
+        tabHistory.addAll(history);
+    }
+}

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryControllerTest.java
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryControllerTest.java
@@ -1,0 +1,33 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CurrentTabHistoryControllerTest {
+    @Mock
+    private FragNavPopController mockFragNavPopController;
+
+    @Test
+    public void testPopDelegatedWhenPopCalled() {
+        // Given
+        CurrentTabHistoryController currentTabHistoryController = new CurrentTabHistoryController(
+                mockFragNavPopController);
+
+        // When
+        currentTabHistoryController.popFragments(1, null);
+
+        // Then
+        verify(mockFragNavPopController, times(1)).tryPopFragments(eq(1), isNull(FragNavTransactionOptions.class));
+    }
+}

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.java
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.java
@@ -1,0 +1,241 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.os.Bundle;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UniqueTabHistoryControllerTest {
+    @Mock
+    private FragNavPopController mockFragNavPopController;
+
+    @Mock
+    private FragNavSwitchController mockFragNavSwitchController;
+
+    @Mock
+    private Bundle mockBundle;
+
+    @Mock
+    private FragNavTransactionOptions mockTransactionOptions;
+
+    private UniqueTabHistoryController uniqueTabHistoryController;
+
+    @Before
+    public void setUp() {
+        uniqueTabHistoryController = new UniqueTabHistoryController(mockFragNavPopController,
+                mockFragNavSwitchController);
+        mockNavSwitchController(uniqueTabHistoryController);
+        mockBundle();
+    }
+
+    @Test
+    public void testNoSwitchWhenCurrentStackIsLargerThanPopCount() {
+        // Given
+        uniqueTabHistoryController.switchTab(1);
+        uniqueTabHistoryController.switchTab(2);
+        when(mockFragNavPopController.tryPopFragments(eq(1), eq(mockTransactionOptions))).thenReturn(1);
+
+        // When
+        boolean result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, never()).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @Test
+    public void testPopDoesNothingWhenPopIsCalledWithNothingToPopWithNoHistory() {
+        // Given
+        uniqueTabHistoryController.switchTab(1);
+
+        // When
+        boolean result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertFalse(result);
+        verify(mockFragNavSwitchController, never()).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @Test
+    public void testPopSwitchesTabWhenPopIsCalledWithNothingToPopAndHasHistory() {
+        // Given
+        uniqueTabHistoryController.switchTab(1);
+        uniqueTabHistoryController.switchTab(2);
+
+        // When
+        boolean result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions));
+    }
+
+    @Test
+    public void testSwitchWhenCurrentStackIsNotLargerThanPopCount() {
+        // Given
+        uniqueTabHistoryController.switchTab(1);
+        uniqueTabHistoryController.switchTab(2);
+        when(mockFragNavPopController.tryPopFragments(eq(2), eq(mockTransactionOptions))).thenReturn(1);
+
+        // When
+        boolean result = uniqueTabHistoryController.popFragments(2, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions));
+    }
+
+    @Test
+    public void testTabsUniquelyRollbackWhenPopAllAvailableItemsInOneStep() {
+        // Given
+
+        // Navigating ahead through tabs
+        for (int i = 1; i < 6; i++) {
+            uniqueTabHistoryController.switchTab(i);
+        }
+
+        // Navigating backwards through tabs
+        for (int i = 5; i > 0; i--) {
+            uniqueTabHistoryController.switchTab(i);
+        }
+
+        // Every tab contains 1 item
+        for (int i = 7; i < 16; i += 2) {
+            when(mockFragNavPopController.tryPopFragments(eq(i), eq(mockTransactionOptions))).thenReturn(1);
+        }
+
+        // When
+        boolean result = uniqueTabHistoryController.popFragments(15, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(4)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+    }
+
+    @Test
+    public void testTabsUniquelyRollbackWhenPopAllAvailableItemsInDifferentSteps() {
+        // Given
+
+        // Navigating ahead through tabs
+        for (int i = 1; i < 6; i++) {
+            uniqueTabHistoryController.switchTab(i);
+        }
+
+        // Navigating backwards through tabs
+        for (int i = 5; i > 0; i--) {
+            uniqueTabHistoryController.switchTab(i);
+        }
+
+        // When
+        for (int i = 0; i < 4; i++) {
+            assertTrue(uniqueTabHistoryController.popFragments(1, mockTransactionOptions));
+        }
+        assertFalse(uniqueTabHistoryController.popFragments(1, mockTransactionOptions));
+
+        // Then
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(4)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+    }
+
+    @Test
+    public void testHistoryIsSavedAndRestoredWhenSaveCalledNewInstanceCreatedRestoreCalled() {
+        // Given
+        for (int i = 5; i > 0; i--) {
+            uniqueTabHistoryController.switchTab(i);
+        }
+
+        // When
+        uniqueTabHistoryController.onSaveInstanceState(mockBundle);
+        UniqueTabHistoryController newUniqueTabHistoryController = new UniqueTabHistoryController(
+                mockFragNavPopController,
+                mockFragNavSwitchController);
+        mockNavSwitchController(newUniqueTabHistoryController);
+        newUniqueTabHistoryController.restoreFromBundle(mockBundle);
+        for (int i = 0; i < 4; i++) {
+            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions));
+        }
+
+        // Then
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(4)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+    }
+
+    private void mockNavSwitchController(final UniqueTabHistoryController uniqueTabHistoryController) {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                uniqueTabHistoryController.switchTab((Integer) invocation.getArgument(0));
+                return null;
+            }
+        }).when(mockFragNavSwitchController).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockBundle() {
+        final ArrayList<Integer> storage = new ArrayList<>();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                storage.clear();
+                storage.addAll(((ArrayList<Integer>) invocation.getArgument(1)));
+                return null;
+            }
+        }).when(mockBundle).putIntegerArrayList(anyString(), any(ArrayList.class));
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                if (storage.size() > 0) {
+                    return storage;
+                }
+                return null;
+            }
+        }).when(mockBundle).getIntegerArrayList(anyString());
+    }
+}

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.java
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.java
@@ -1,0 +1,247 @@
+package com.ncapdevi.fragnav.tabhistory;
+
+import android.os.Bundle;
+
+import com.ncapdevi.fragnav.FragNavPopController;
+import com.ncapdevi.fragnav.FragNavSwitchController;
+import com.ncapdevi.fragnav.FragNavTransactionOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnlimitedTabHistoryControllerTest {
+    @Mock
+    private FragNavPopController mockFragNavPopController;
+
+    @Mock
+    private FragNavSwitchController mockFragNavSwitchController;
+
+    @Mock
+    private Bundle mockBundle;
+
+    @Mock
+    private FragNavTransactionOptions mockTransactionOptions;
+
+    private UnlimitedTabHistoryController unlimitedTabHistoryController;
+
+    @Before
+    public void setUp() {
+        unlimitedTabHistoryController = new UnlimitedTabHistoryController(mockFragNavPopController,
+                mockFragNavSwitchController);
+        mockNavSwitchController(unlimitedTabHistoryController);
+        mockBundle();
+    }
+
+    @Test
+    public void testNoSwitchWhenCurrentStackIsLargerThanPopCount() {
+        // Given
+        unlimitedTabHistoryController.switchTab(1);
+        unlimitedTabHistoryController.switchTab(2);
+        when(mockFragNavPopController.tryPopFragments(eq(1), eq(mockTransactionOptions))).thenReturn(1);
+
+        // When
+        boolean result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, never()).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @Test
+    public void testPopDoesNothingWhenPopIsCalledWithNothingToPopWithNoHistory() {
+        // Given
+        unlimitedTabHistoryController.switchTab(1);
+
+        // When
+        boolean result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertFalse(result);
+        verify(mockFragNavSwitchController, never()).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @Test
+    public void testPopSwitchesTabWhenPopIsCalledWithNothingToPopAndHasHistory() {
+        // Given
+        unlimitedTabHistoryController.switchTab(1);
+        unlimitedTabHistoryController.switchTab(2);
+
+        // When
+        boolean result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions));
+    }
+
+    @Test
+    public void testSwitchWhenCurrentStackIsNotLargerThanPopCount() {
+        // Given
+        unlimitedTabHistoryController.switchTab(1);
+        unlimitedTabHistoryController.switchTab(2);
+        when(mockFragNavPopController.tryPopFragments(eq(2), eq(mockTransactionOptions))).thenReturn(1);
+
+        // When
+        boolean result = unlimitedTabHistoryController.popFragments(2, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions));
+    }
+
+    @Test
+    public void testTabsUnlimitedRollbackWhenPopAllAvailableItemsInOneStep() {
+        // Given
+
+        // Navigating ahead through tabs
+        for (int i = 1; i < 6; i++) {
+            unlimitedTabHistoryController.switchTab(i);
+        }
+
+        // Navigating backwards through tabs
+        for (int i = 5; i > 0; i--) {
+            unlimitedTabHistoryController.switchTab(i);
+        }
+
+        // Every tab contains 1 item
+        for (int i = 7; i < 16; i += 2) {
+            when(mockFragNavPopController.tryPopFragments(eq(i), eq(mockTransactionOptions))).thenReturn(1);
+        }
+
+        // When
+        boolean result = unlimitedTabHistoryController.popFragments(15, mockTransactionOptions);
+
+        // Then
+        assertTrue(result);
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(9)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5, 5, 4, 3, 2, 1]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+        for (int i = 4; i < 9; i++) {
+            assertEquals((int) allValues.get(i), 9 - i);
+        }
+    }
+
+    @Test
+    public void testTabsUnlimitedRollbackWhenPopAllAvailableItemsInDifferentSteps() {
+        // Given
+
+        // Navigating ahead through tabs
+        for (int i = 1; i < 6; i++) {
+            unlimitedTabHistoryController.switchTab(i);
+        }
+
+        // Navigating backwards through tabs
+        for (int i = 5; i > 0; i--) {
+            unlimitedTabHistoryController.switchTab(i);
+        }
+
+        // When
+        for (int i = 0; i < 9; i++) {
+            assertTrue(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions));
+        }
+        assertFalse(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions));
+
+        // Then
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(9)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5, 5, 4, 3, 2, 1]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+        for (int i = 4; i < 9; i++) {
+            assertEquals((int) allValues.get(i), 9 - i);
+        }
+    }
+
+    @Test
+    public void testHistoryIsSavedAndRestoredWhenSaveCalledNewInstanceCreatedRestoreCalled() {
+        // Given
+        for (int i = 5; i > 0; i--) {
+            unlimitedTabHistoryController.switchTab(i);
+        }
+
+        // When
+        unlimitedTabHistoryController.onSaveInstanceState(mockBundle);
+        UnlimitedTabHistoryController newUniqueTabHistoryController = new UnlimitedTabHistoryController(
+                mockFragNavPopController,
+                mockFragNavSwitchController);
+        mockNavSwitchController(newUniqueTabHistoryController);
+        newUniqueTabHistoryController.restoreFromBundle(mockBundle);
+        for (int i = 0; i < 4; i++) {
+            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions));
+        }
+
+        // Then
+        ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(mockFragNavSwitchController, times(4)).switchTab(argumentCaptor.capture(), eq(mockTransactionOptions));
+        List<Integer> allValues = argumentCaptor.getAllValues();
+
+        // The history is [2, 3, 4, 5]
+        for (int i = 1; i < 5; i++) {
+            assertEquals((int) allValues.get(i - 1), i + 1);
+        }
+    }
+
+    private void mockNavSwitchController(final UnlimitedTabHistoryController uniqueTabHistoryController) {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                uniqueTabHistoryController.switchTab((Integer) invocation.getArgument(0));
+                return null;
+            }
+        }).when(mockFragNavSwitchController).switchTab(anyInt(), nullable(FragNavTransactionOptions.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockBundle() {
+        final ArrayList<Integer> storage = new ArrayList<>();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                storage.clear();
+                storage.addAll(((ArrayList<Integer>) invocation.getArgument(1)));
+                return null;
+            }
+        }).when(mockBundle).putIntegerArrayList(anyString(), any(ArrayList.class));
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                if (storage.size() > 0) {
+                    return storage;
+                }
+                return null;
+            }
+        }).when(mockBundle).getIntegerArrayList(anyString());
+    }
+}


### PR DESCRIPTION
Hi @ncapdevi,

This is the first rough implementation of our use case where developer can control with the builder flag what happens when trying to pop from a stack that already has only the root fragment (so far it was an unsupported exception).

Depending on the selected strategy the following will happen:
- Current Tab: This is the original way, exception will be raised
- Unique Tab History: Navigation will be triggered backwards in history (each tab is kept only once)
- Unlimited Tab History: Navigation will be triggered backwards in exactly in the order the user was switching between tabs

(Tab switching can only happen if we're on the root fragment of the current tab, if not the fragments will be popped from the current stack)

We kept backward compatibility with one change - popFragment will return boolean to indicate whether any pop or switch happened - (however in Current Tab mode we kept the exception to remain backward compatible)

We added test cases for the different strategies and updated the sample app to use the Unique Tab History.

Please review if you have time and we're open to any suggestion / changes.

Thanks!