### PR TITLE
Change exception type on restoreFromBundle method

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
@@ -19,6 +19,7 @@ import com.ncapdevi.fragnav.tabhistory.UniqueTabHistoryController;
 import com.ncapdevi.fragnav.tabhistory.UnlimitedTabHistoryController;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -945,7 +946,7 @@ public class FragNavController {
 
             //Successfully restored state
             return true;
-        } catch (Throwable t) {
+        } catch (JSONException e) {
             return false;
         }
     }


### PR DESCRIPTION
I had an exception on my TransactionListener and this try/catch was hiding the real error and throwing this exception **"Fatal Exception: java.lang.IllegalStateException: Can't change tag of fragment."**

regards