### PR TITLE
Revert optional call of executePendingTransactions

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.java
@@ -675,6 +675,16 @@ public class FragNavController {
         return fragment.getClass().getName() + ++mTagCount;
     }
 
+    /**
+     * This check is here to prevent recursive entries into executePendingTransactions
+     */
+    private void executePendingTransactions() {
+        if (!mExecutingTransaction) {
+            mExecutingTransaction = true;
+            mFragmentManager.executePendingTransactions();
+            mExecutingTransaction = false;
+        }
+    }
 
     /**
      * Private helper function to clear out the fragment manager on initialization. All fragment management should be done via FragNav.
@@ -742,6 +752,7 @@ public class FragNavController {
         } else {
             fragmentTransaction.commit();
         }
+        executePendingTransactions();
     }
 
     //endregion
@@ -819,20 +830,6 @@ public class FragNavController {
     public boolean isStateSaved() {
         return mFragmentManager.isStateSaved();
     }
-
-    /**
-     *  Use this if you need to make sure that pending transactions occur immediately. This call is safe to
-     *  call as often as you want as there's a check to prevent multiple executePendingTransactions at once
-     *
-     */
-    public void executePendingTransactions() {
-        if (!mExecutingTransaction) {
-            mExecutingTransaction = true;
-            mFragmentManager.executePendingTransactions();
-            mExecutingTransaction = false;
-        }
-    }
-
 
     //endregion
 


### PR DESCRIPTION
- Revert optional executePendingTransactions since it makes the mechanism flaky

Hi @ncapdevi,

I've seen executePendingTransactions have been changed to be optionally called by the developer but as I observed in our projects there are lots of cases when it ends up in unwanted crashes. I created a sample change on the following branch to the test application:

[Exploit Branch](https://github.com/mateherber/FragNav/tree/feature/exploit_optional_execute_pending)
[Relevant Commit](https://github.com/mateherber/FragNav/commit/3c36830012678d1e2a2d26996df997c5d13d25fa)

The test app instantly crashes after switching tabs too fast.
So I'd suggest to revert this change while we can come up with better solution that is stable.

Thank you for considering!