### PR TITLE
Added Hide/Show and Hide/Detach Show/Attach hybrid modes as option

### DIFF
--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.java
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.java
@@ -2,6 +2,7 @@ package com.ncapdevi.sample.activities;
 
 import android.os.Bundle;
 import android.support.annotation.IdRes;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
@@ -46,13 +47,15 @@ public class BottomTabsActivity extends AppCompatActivity implements BaseFragmen
                 .popStrategy(FragNavTabHistoryController.UNIQUE_TAB_HISTORY)
                 .switchController(new FragNavSwitchController() {
                     @Override
-                    public void switchTab(int index, FragNavTransactionOptions transactionOptions) {
+                    public void switchTab(int index, @Nullable FragNavTransactionOptions transactionOptions) {
                         bottomBar.selectTabAtPosition(index);
                     }
                 })
+                .fragmentHideStrategy(FragNavController.DETACH_ON_NAVIGATE_HIDE_ON_SWITCH)
+                .eager(true)
                 .build();
 
-
+        mNavController.executePendingTransactions();
         bottomBar.setOnTabSelectListener(new OnTabSelectListener() {
             @Override
             public void onTabSelected(@IdRes int tabId) {

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavPopController.kt
@@ -2,5 +2,5 @@ package com.ncapdevi.fragnav
 
 interface FragNavPopController {
     @Throws(UnsupportedOperationException::class)
-    fun tryPopFragments(popDepth: Int, transactionOptions: FragNavTransactionOptions): Int
+    fun tryPopFragments(popDepth: Int, transactionOptions: FragNavTransactionOptions?): Int
 }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavSwitchController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavSwitchController.kt
@@ -1,5 +1,5 @@
 package com.ncapdevi.fragnav
 
 interface FragNavSwitchController {
-    fun switchTab(@FragNavController.TabIndex index: Int, transactionOptions: FragNavTransactionOptions)
+    fun switchTab(@FragNavController.TabIndex index: Int, transactionOptions: FragNavTransactionOptions?)
 }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CollectionFragNavTabHistoryController.kt
@@ -17,7 +17,7 @@ abstract class CollectionFragNavTabHistoryController(fragNavPopController: FragN
 
     @Throws(UnsupportedOperationException::class)
     override fun popFragments(popDepth: Int,
-                              transactionOptions: FragNavTransactionOptions): Boolean {
+                              transactionOptions: FragNavTransactionOptions?): Boolean {
         var popDepth = popDepth
         var changed = false
         var switched: Boolean

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryController.kt
@@ -9,7 +9,7 @@ internal class CurrentTabHistoryController(fragNavPopController: FragNavPopContr
 
     @Throws(UnsupportedOperationException::class)
     override fun popFragments(popDepth: Int,
-                              transactionOptions: FragNavTransactionOptions): Boolean {
+                              transactionOptions: FragNavTransactionOptions?): Boolean {
         return fragNavPopController.tryPopFragments(popDepth, transactionOptions) > 0
     }
 

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
@@ -12,7 +12,7 @@ interface FragNavTabHistoryController {
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
     annotation class PopStrategy
 
-    fun popFragments(popDepth: Int, transactionOptions: FragNavTransactionOptions): Boolean
+    fun popFragments(popDepth: Int, transactionOptions: FragNavTransactionOptions?): Boolean
 
     fun switchTab(index: Int)
 

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/MockTest.java
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/MockTest.java
@@ -27,8 +27,9 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 
 @SuppressWarnings("ResourceType")
 @RunWith(MockitoJUnitRunner.class)
@@ -50,13 +51,6 @@ public class MockTest implements FragNavController.TransactionListener {
     public void initMocks() {
         mockFragmentManager();
         mockFragmentTransaction();
-        mFragNavController = FragNavController.newBuilder(mBundle, mFragmentManager, 1)
-                .transactionListener(this)
-                .rootFragment(mock(Fragment.class))
-                .build();
-
-        assertEquals(FragNavController.TAB1, mFragNavController.getCurrentStackIndex());
-        assertNotNull(mFragNavController.getCurrentStack());
     }
 
     private void mockFragmentTransaction() {
@@ -89,6 +83,24 @@ public class MockTest implements FragNavController.TransactionListener {
 
         assertEquals(FragNavController.TAB1, mFragNavController.getCurrentStackIndex());
         assertNotNull(mFragNavController.getCurrentStack());
+    }
+
+    @Test
+    public void testConstructionWhenMultipleFragmentsEagerMode() {
+        List<Fragment> rootFragments = new ArrayList<>();
+        rootFragments.add(new Fragment());
+        rootFragments.add(new Fragment());
+
+        mFragNavController = FragNavController.newBuilder(null, mFragmentManager, 1)
+                .rootFragments(rootFragments)
+                .fragmentHideStrategy(FragNavController.DETACH_ON_NAVIGATE_HIDE_ON_SWITCH)
+                .eager(true)
+                .build();
+
+        assertEquals(FragNavController.TAB1, mFragNavController.getCurrentStackIndex());
+        assertNotNull(mFragNavController.getCurrentStack());
+        assertEquals(mFragNavController.getSize(), 2);
+        verify(mFragmentTransaction, times(2)).add(anyInt(), any(Fragment.class), anyString());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -180,6 +192,13 @@ public class MockTest implements FragNavController.TransactionListener {
     @Test
     @SuppressWarnings("ConstantConditions")
     public void pushPopClear() {
+        mFragNavController = FragNavController.newBuilder(mBundle, mFragmentManager, 1)
+                .transactionListener(this)
+                .rootFragment(mock(Fragment.class))
+                .build();
+
+        assertEquals(FragNavController.TAB1, mFragNavController.getCurrentStackIndex());
+        assertNotNull(mFragNavController.getCurrentStack());
 
         int size = mFragNavController.getCurrentStack().size();
 


### PR DESCRIPTION
Added Hide/Show and Hide/Detach Show/Attach hybrid modes as option
Added Eager mode to precreate all Root fragments initially
Fixed several Kotlin nullability issues

Hi @ncapdevi,
I've seen that FragNavController has not yet been transformed to Kotlin so I created the PR for the java but still on the kotlin branch.
In this PR we added the possibility to change attach/detach (default) behavior to show/hide or a hybrid (we actually use in our app) when switching between tabs is really fast (every tab's topmost fragment is not detached but hidden) however navigation still happens with attach/detach.

The reason behind this is that while you have written in the readme that reconstructing the activity / fragment from state is pretty standard on Android we experienced lagging/bad user experience when we were rebuilding our more complex pages when the user was navigating between tabs (i.e. reloading a complex recycleview with all the dense data on cards is not something that can be done without drops in framerate).

We implemented this so when user is switching between tabs is blazing fast but we still don't hold everything in memory (just as many fragments as the number of our tabs).

We also added a so called eager mode (which makes sense for the two types of show/hide modes) where we initially create all root fragments so the UI won't glitch when the user first navigates to these screens.

I'll update the README for both this PR and the backstack navigation PR in a separate one. I'll also make special emphasis on that using these new add/remove methods you'll have to take care of fragment lifecycle manually (i.e. Show/Hide doesn't trigger any onPause/onStop/onStart/onResume cycle, neither creating new UI (with onCreateView). So this has to be used with additional care.

I hope all this makes sense.