### PR TITLE
- initial attempt at removing the fragment stacks and just maintaining the tags

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
@@ -15,7 +15,6 @@ import com.ncapdevi.sample.fragments.*
 import com.roughike.bottombar.BottomBar
 
 
-
 class BottomTabsActivity : AppCompatActivity(), BaseFragment.FragmentNavigation, FragNavController.TransactionListener, FragNavController.RootFragmentListener {
 
     private var fragNavController: FragNavController? = null

--- a/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
@@ -31,8 +31,9 @@ open class BaseFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         if (cachedView == null) {
-            cachedView = inflater.inflate(R.layout.fragment_main, container, false)
-            btn = cachedView!!.findViewById(R.id.button)
+            cachedView = inflater.inflate(R.layout.fragment_main, container, false)?.apply {
+                btn = findViewById(R.id.button)
+            }
         }
         return cachedView
     }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -65,7 +65,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
         //Attempt to restore from bundle, if not, initialize
         if (!restoreFromBundle(savedInstanceState, builder.rootFragments)) {
             for (i in 0 until builder.numberOfTabs) {
-                fragmentStacksTags.add(Stack<String>())
+                fragmentStacksTags.add(Stack())
             }
 
             initialize(builder.selectedTabIndex)
@@ -91,10 +91,9 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
                 return null
             }
             //if not, try to pull it from the stack
-
             val fragmentStack = fragmentStacksTags[currentStackIndex]
             if (!fragmentStack.isEmpty()) {
-                val fragmentByTag = fragmentManger.findFragmentByTag(fragmentStack.peek())
+                val fragmentByTag = getFragment(fragmentStack.peek())
                 if (fragmentByTag != null) {
                     mCurrentFrag = fragmentByTag
                 }
@@ -555,7 +554,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
         val fragmentStack = fragmentStacksTags[currentStackIndex]
         var fragment: Fragment? = null
         if (fragmentStack.isNotEmpty()) {
-            fragment = fragmentManger.findFragmentByTag(fragmentStack.peek())
+            fragment = getFragment(fragmentStack.peek())
             if (fragment != null) {
                 if (isAttach) {
                     ft.attach(fragment)
@@ -591,6 +590,10 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
     @CheckResult
     private fun generateTag(fragment: Fragment): String {
         return fragment.javaClass.name + ++tagCount
+    }
+
+    private fun getFragment(tag: String): Fragment? {
+        return fragmentManger.findFragmentByTag(tag)
     }
 
 

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -182,7 +182,9 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
         for (i in lowerBound until upperBound) {
             currentStackIndex = i
             val fragment = getRootFragment(i)
-            ft.add(containerId, fragment, generateTag(fragment))
+            val fragmentTag = generateTag(fragment)
+            fragmentStacksTags[currentStackIndex].push(fragmentTag)
+            ft.add(containerId, fragment, fragmentTag)
             if (i != index) {
                 if (shouldDetachAttachOnSwitch()) {
                     ft.detach(fragment)

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MemberVisibilityCanBePrivate")
+
 package com.ncapdevi.fragnav
 
 import android.annotation.SuppressLint
@@ -677,14 +679,11 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
      *
      * @return requested stack
      */
-    @Suppress("UNCHECKED_CAST")
     @CheckResult
+    @Throws(IndexOutOfBoundsException::class)
     fun getStack(@TabIndex index: Int): Stack<Fragment>? {
         if (index == NO_TAB) {
             return null
-        }
-        if (index >= fragmentStacksTags.size) {
-            throw IndexOutOfBoundsException("Can't get an index that's larger than we've setup")
         }
         return fragmentStacksTags[index].mapNotNullTo(Stack(), { s -> getFragment(s) })
     }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -69,6 +69,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
             for (i in 0 until builder.numberOfTabs) {
                 fragmentStacksTags.add(Stack())
             }
+            rootFragments.addAll(builder.rootFragments)
 
             initialize(builder.selectedTabIndex)
         } else {
@@ -535,9 +536,17 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
 
         if (fragmentStacksTags[index].isNotEmpty()) {
             fragment = fragmentManger.findFragmentByTag(fragmentStacksTags[index].peek())
-        } else if (rootFragmentListener != null) {
+        }
+
+        if (fragment == null && rootFragmentListener != null) {
             fragment = rootFragmentListener.getRootFragment(index)
         }
+
+        if (fragment == null && index < rootFragments.size) {
+            fragment = rootFragments[index]
+        }
+
+
         if (fragment == null) {
             throw IllegalStateException("Either you haven't past in a fragment at this index in your constructor, or you haven't " + "provided a way to create it while via your RootFragmentListener.getRootFragment(index)")
         }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -537,9 +537,6 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
             fragment = fragmentManger.findFragmentByTag(fragmentStacksTags[index].peek())
         } else if (rootFragmentListener != null) {
             fragment = rootFragmentListener.getRootFragment(index)
-            if (currentStackIndex != NO_TAB) {
-                // fragmentStacks[currentStackIndex].push(fragment)
-            }
         }
         if (fragment == null) {
             throw IllegalStateException("Either you haven't past in a fragment at this index in your constructor, or you haven't " + "provided a way to create it while via your RootFragmentListener.getRootFragment(index)")

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -686,8 +686,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
         if (index >= fragmentStacksTags.size) {
             throw IndexOutOfBoundsException("Can't get an index that's larger than we've setup")
         }
-        //return fragmentStacksTags[index].clone() as Stack<Fragment>
-        return currentStack
+        return fragmentStacksTags[index].mapNotNullTo(Stack(), { s -> getFragment(s) })
     }
 
     /**

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
@@ -39,8 +39,8 @@ class FragNavTransactionOptionsTest {
                 .addSharedElement(Pair(null, "test"))
                 .addSharedElement(Pair(null, "test2")).build()
 
-        assertTrue(breadCrumbShortTitle.equals(fragNavTransactionOptions.breadCrumbShortTitle!!, ignoreCase = true))
-        assertTrue(breadCrumbTitle.equals(fragNavTransactionOptions.breadCrumbTitle!!, ignoreCase = true))
+        assertTrue(breadCrumbShortTitle.equals(fragNavTransactionOptions.breadCrumbShortTitle, ignoreCase = true))
+        assertTrue(breadCrumbTitle.equals(fragNavTransactionOptions.breadCrumbTitle, ignoreCase = true))
 
         assertTrue(transitionStyle == fragNavTransactionOptions.transitionStyle)
 

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/MockTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/MockTest.kt
@@ -26,7 +26,7 @@ class MockTest : FragNavController.TransactionListener {
     @Mock
     private lateinit var mFragmentTransaction: FragmentTransaction
 
-    private var mFragNavController: FragNavController? = null
+    private lateinit var mFragNavController: FragNavController
 
     private val fragmentTagMap: MutableMap<String, Fragment> = mutableMapOf()
 
@@ -64,8 +64,8 @@ class MockTest : FragNavController.TransactionListener {
                 .rootFragments(rootFragments)
                 .build()
 
-        assertEquals(FragNavController.TAB1.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertNotNull(mFragNavController!!.currentStack)
+        assertEquals(FragNavController.TAB1.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertNotNull(mFragNavController.currentStack)
     }
 
     @Test
@@ -80,9 +80,9 @@ class MockTest : FragNavController.TransactionListener {
                 .eager(true)
                 .build()
 
-        assertEquals(FragNavController.TAB1.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertNotNull(mFragNavController!!.currentStack)
-        assertEquals(mFragNavController!!.size.toLong(), 2)
+        assertEquals(FragNavController.TAB1.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertNotNull(mFragNavController.currentStack)
+        assertEquals(mFragNavController.size.toLong(), 2)
         verify<FragmentTransaction>(mFragmentTransaction, times(2)).add(ArgumentMatchers.anyInt(), ArgumentMatchers.any(Fragment::class.java), ArgumentMatchers.anyString())
     }
 
@@ -110,8 +110,8 @@ class MockTest : FragNavController.TransactionListener {
                 .selectedTabIndex(FragNavController.NO_TAB)
                 .build()
 
-        assertEquals(FragNavController.NO_TAB.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertNull(mFragNavController!!.currentStack)
+        assertEquals(FragNavController.NO_TAB.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertNull(mFragNavController.currentStack)
     }
 
     @Test
@@ -124,8 +124,8 @@ class MockTest : FragNavController.TransactionListener {
                 .selectedTabIndex(FragNavController.TAB3)
                 .build()
 
-        assertEquals(FragNavController.TAB3.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertNotNull(mFragNavController!!.currentStack)
+        assertEquals(FragNavController.TAB3.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertNotNull(mFragNavController.currentStack)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -150,25 +150,25 @@ class MockTest : FragNavController.TransactionListener {
                 .selectedTabIndex(FragNavController.TAB1)
                 .build()
 
-        mFragNavController!!.switchTab(FragNavController.TAB2)
-        mFragNavController!!.pushFragment(Fragment())
-        mFragNavController!!.pushFragment(Fragment())
-        mFragNavController!!.pushFragment(Fragment())
+        mFragNavController.switchTab(FragNavController.TAB2)
+        mFragNavController.pushFragment(Fragment())
+        mFragNavController.pushFragment(Fragment())
+        mFragNavController.pushFragment(Fragment())
 
-        val currentFragment = mFragNavController!!.currentFrag
+        val currentFragment = mFragNavController.currentFrag
 
         val bundle = Bundle()
 
-        mFragNavController!!.onSaveInstanceState(bundle)
+        mFragNavController.onSaveInstanceState(bundle)
 
         mFragNavController = FragNavController.newBuilder(bundle, mFragmentManager, 1)
                 .rootFragments(rootFragments)
                 .selectedTabIndex(FragNavController.TAB1)
                 .build()
 
-        assertEquals(FragNavController.TAB2.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertEquals(4, mFragNavController!!.currentStack!!.size.toLong())
-        assertEquals(currentFragment, mFragNavController!!.currentFrag)
+        assertEquals(FragNavController.TAB2.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertEquals(4, mFragNavController.currentStack!!.size.toLong())
+        assertEquals(currentFragment, mFragNavController.currentFrag)
     }
 
     @Test
@@ -178,26 +178,26 @@ class MockTest : FragNavController.TransactionListener {
                 .rootFragment(mock(Fragment::class.java))
                 .build()
 
-        assertEquals(FragNavController.TAB1.toLong(), mFragNavController!!.currentStackIndex.toLong())
-        assertNotNull(mFragNavController!!.currentStack)
+        assertEquals(FragNavController.TAB1.toLong(), mFragNavController.currentStackIndex.toLong())
+        assertNotNull(mFragNavController.currentStack)
 
-        var size = mFragNavController!!.currentStack!!.size
+        var size = mFragNavController.currentStack!!.size
 
-        mFragNavController!!.pushFragment(mock(Fragment::class.java))
-        assertTrue(mFragNavController!!.currentStack!!.size == ++size)
+        mFragNavController.pushFragment(mock(Fragment::class.java))
+        assertTrue(mFragNavController.currentStack!!.size == ++size)
 
-        mFragNavController!!.pushFragment(mock(Fragment::class.java))
-        assertTrue(mFragNavController!!.currentStack!!.size == ++size)
+        mFragNavController.pushFragment(mock(Fragment::class.java))
+        assertTrue(mFragNavController.currentStack!!.size == ++size)
 
-        mFragNavController!!.pushFragment(mock(Fragment::class.java))
-        assertTrue(mFragNavController!!.currentStack!!.size == ++size)
+        mFragNavController.pushFragment(mock(Fragment::class.java))
+        assertTrue(mFragNavController.currentStack!!.size == ++size)
 
-        mFragNavController!!.popFragment()
-        assertTrue(mFragNavController!!.currentStack!!.size == --size)
+        mFragNavController.popFragment()
+        assertTrue(mFragNavController.currentStack!!.size == --size)
 
-        mFragNavController!!.clearStack()
-        assertTrue(mFragNavController!!.currentStack!!.size == 1)
-        assertTrue(mFragNavController!!.isRootFragment)
+        mFragNavController.clearStack()
+        assertTrue(mFragNavController.currentStack!!.size == 1)
+        assertTrue(mFragNavController.isRootFragment)
     }
 
     override fun onTabTransaction(fragment: Fragment?, index: Int) {

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/CurrentTabHistoryControllerTest.kt
@@ -14,13 +14,13 @@ import org.mockito.junit.MockitoJUnitRunner
 @RunWith(MockitoJUnitRunner::class)
 class CurrentTabHistoryControllerTest {
     @Mock
-    private val mockFragNavPopController: FragNavPopController? = null
+    private lateinit var mockFragNavPopController: FragNavPopController
 
     @Test
     fun testPopDelegatedWhenPopCalled() {
         // Given
         val currentTabHistoryController = CurrentTabHistoryController(
-                mockFragNavPopController!!)
+                mockFragNavPopController)
 
         // When
         currentTabHistoryController.popFragments(1, null)

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
@@ -26,36 +26,35 @@ import java.util.*
 @RunWith(MockitoJUnitRunner::class)
 class UniqueTabHistoryControllerTest {
     @Mock
-    private val mockFragNavPopController: FragNavPopController? = null
+    private lateinit var mockFragNavPopController: FragNavPopController
 
     @Mock
-    private val mockFragNavSwitchController: FragNavSwitchController? = null
+    private lateinit var mockFragNavSwitchController: FragNavSwitchController
 
     @Mock
-    private val mockBundle: Bundle? = null
+    private lateinit var mockBundle: Bundle
 
     @Mock
-    private val mockTransactionOptions: FragNavTransactionOptions? = null
+    private lateinit var mockTransactionOptions: FragNavTransactionOptions
 
-    private var uniqueTabHistoryController: UniqueTabHistoryController? = null
+    private lateinit var uniqueTabHistoryController: UniqueTabHistoryController
 
     @Before
     fun setUp() {
-        uniqueTabHistoryController = UniqueTabHistoryController(mockFragNavPopController!!,
-                mockFragNavSwitchController!!)
-        mockNavSwitchController(uniqueTabHistoryController!!)
+        uniqueTabHistoryController = UniqueTabHistoryController(mockFragNavPopController, mockFragNavSwitchController)
+        mockNavSwitchController(uniqueTabHistoryController)
         mockBundle()
     }
 
     @Test
     fun testNoSwitchWhenCurrentStackIsLargerThanPopCount() {
         // Given
-        uniqueTabHistoryController!!.switchTab(1)
-        uniqueTabHistoryController!!.switchTab(2)
-        `when`(mockFragNavPopController!!.tryPopFragments(eq(1), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+        uniqueTabHistoryController.switchTab(1)
+        uniqueTabHistoryController.switchTab(2)
+        `when`(mockFragNavPopController.tryPopFragments(eq(1), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
 
         // When
-        val result = uniqueTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -65,10 +64,10 @@ class UniqueTabHistoryControllerTest {
     @Test
     fun testPopDoesNothingWhenPopIsCalledWithNothingToPopWithNoHistory() {
         // Given
-        uniqueTabHistoryController!!.switchTab(1)
+        uniqueTabHistoryController.switchTab(1)
 
         // When
-        val result = uniqueTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertFalse(result)
@@ -78,11 +77,11 @@ class UniqueTabHistoryControllerTest {
     @Test
     fun testPopSwitchesTabWhenPopIsCalledWithNothingToPopAndHasHistory() {
         // Given
-        uniqueTabHistoryController!!.switchTab(1)
-        uniqueTabHistoryController!!.switchTab(2)
+        uniqueTabHistoryController.switchTab(1)
+        uniqueTabHistoryController.switchTab(2)
 
         // When
-        val result = uniqueTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -92,12 +91,12 @@ class UniqueTabHistoryControllerTest {
     @Test
     fun testSwitchWhenCurrentStackIsNotLargerThanPopCount() {
         // Given
-        uniqueTabHistoryController!!.switchTab(1)
-        uniqueTabHistoryController!!.switchTab(2)
-        `when`(mockFragNavPopController!!.tryPopFragments(eq(2), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+        uniqueTabHistoryController.switchTab(1)
+        uniqueTabHistoryController.switchTab(2)
+        `when`(mockFragNavPopController.tryPopFragments(eq(2), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
 
         // When
-        val result = uniqueTabHistoryController!!.popFragments(2, mockTransactionOptions)
+        val result = uniqueTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -110,25 +109,25 @@ class UniqueTabHistoryControllerTest {
 
         // Navigating ahead through tabs
         for (i in 1..5) {
-            uniqueTabHistoryController!!.switchTab(i)
+            uniqueTabHistoryController.switchTab(i)
         }
 
         // Navigating backwards through tabs
         for (i in 5 downTo 1) {
-            uniqueTabHistoryController!!.switchTab(i)
+            uniqueTabHistoryController.switchTab(i)
         }
 
         // Every tab contains 1 item
         run {
             var i = 7
             while (i < 16) {
-                `when`(mockFragNavPopController!!.tryPopFragments(eq(i), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+                `when`(mockFragNavPopController.tryPopFragments(eq(i), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
                 i += 2
             }
         }
 
         // When
-        val result = uniqueTabHistoryController!!.popFragments(15, mockTransactionOptions)
+        val result = uniqueTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -148,19 +147,19 @@ class UniqueTabHistoryControllerTest {
 
         // Navigating ahead through tabs
         for (i in 1..5) {
-            uniqueTabHistoryController!!.switchTab(i)
+            uniqueTabHistoryController.switchTab(i)
         }
 
         // Navigating backwards through tabs
         for (i in 5 downTo 1) {
-            uniqueTabHistoryController!!.switchTab(i)
+            uniqueTabHistoryController.switchTab(i)
         }
 
         // When
         for (i in 0..3) {
-            assertTrue(uniqueTabHistoryController!!.popFragments(1, mockTransactionOptions))
+            assertTrue(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
-        assertFalse(uniqueTabHistoryController!!.popFragments(1, mockTransactionOptions))
+        assertFalse(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
 
         // Then
         val argumentCaptor = ArgumentCaptor.forClass(Int::class.java)
@@ -177,14 +176,14 @@ class UniqueTabHistoryControllerTest {
     fun testHistoryIsSavedAndRestoredWhenSaveCalledNewInstanceCreatedRestoreCalled() {
         // Given
         for (i in 5 downTo 1) {
-            uniqueTabHistoryController!!.switchTab(i)
+            uniqueTabHistoryController.switchTab(i)
         }
 
         // When
-        uniqueTabHistoryController!!.onSaveInstanceState(mockBundle!!)
+        uniqueTabHistoryController.onSaveInstanceState(mockBundle)
         val newUniqueTabHistoryController = UniqueTabHistoryController(
-                mockFragNavPopController!!,
-                mockFragNavSwitchController!!)
+                mockFragNavPopController,
+                mockFragNavSwitchController)
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
@@ -26,36 +26,36 @@ import java.util.*
 @RunWith(MockitoJUnitRunner::class)
 class UnlimitedTabHistoryControllerTest {
     @Mock
-    private val mockFragNavPopController: FragNavPopController? = null
+    private lateinit var mockFragNavPopController: FragNavPopController
 
     @Mock
-    private val mockFragNavSwitchController: FragNavSwitchController? = null
+    private lateinit var mockFragNavSwitchController: FragNavSwitchController
 
     @Mock
-    private val mockBundle: Bundle? = null
+    private lateinit var mockBundle: Bundle
 
     @Mock
-    private val mockTransactionOptions: FragNavTransactionOptions? = null
+    private lateinit var mockTransactionOptions: FragNavTransactionOptions
 
-    private var unlimitedTabHistoryController: UnlimitedTabHistoryController? = null
+    private lateinit var unlimitedTabHistoryController: UnlimitedTabHistoryController
 
     @Before
     fun setUp() {
-        unlimitedTabHistoryController = UnlimitedTabHistoryController(mockFragNavPopController!!,
-                mockFragNavSwitchController!!)
-        mockNavSwitchController(unlimitedTabHistoryController!!)
+        unlimitedTabHistoryController = UnlimitedTabHistoryController(mockFragNavPopController,
+                mockFragNavSwitchController)
+        mockNavSwitchController(unlimitedTabHistoryController)
         mockBundle()
     }
 
     @Test
     fun testNoSwitchWhenCurrentStackIsLargerThanPopCount() {
         // Given
-        unlimitedTabHistoryController!!.switchTab(1)
-        unlimitedTabHistoryController!!.switchTab(2)
-        `when`(mockFragNavPopController!!.tryPopFragments(eq(1), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+        unlimitedTabHistoryController.switchTab(1)
+        unlimitedTabHistoryController.switchTab(2)
+        `when`(mockFragNavPopController.tryPopFragments(eq(1), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
 
         // When
-        val result = unlimitedTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -65,10 +65,10 @@ class UnlimitedTabHistoryControllerTest {
     @Test
     fun testPopDoesNothingWhenPopIsCalledWithNothingToPopWithNoHistory() {
         // Given
-        unlimitedTabHistoryController!!.switchTab(1)
+        unlimitedTabHistoryController.switchTab(1)
 
         // When
-        val result = unlimitedTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertFalse(result)
@@ -78,11 +78,11 @@ class UnlimitedTabHistoryControllerTest {
     @Test
     fun testPopSwitchesTabWhenPopIsCalledWithNothingToPopAndHasHistory() {
         // Given
-        unlimitedTabHistoryController!!.switchTab(1)
-        unlimitedTabHistoryController!!.switchTab(2)
+        unlimitedTabHistoryController.switchTab(1)
+        unlimitedTabHistoryController.switchTab(2)
 
         // When
-        val result = unlimitedTabHistoryController!!.popFragments(1, mockTransactionOptions)
+        val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -92,12 +92,12 @@ class UnlimitedTabHistoryControllerTest {
     @Test
     fun testSwitchWhenCurrentStackIsNotLargerThanPopCount() {
         // Given
-        unlimitedTabHistoryController!!.switchTab(1)
-        unlimitedTabHistoryController!!.switchTab(2)
-        `when`(mockFragNavPopController!!.tryPopFragments(eq(2), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+        unlimitedTabHistoryController.switchTab(1)
+        unlimitedTabHistoryController.switchTab(2)
+        `when`(mockFragNavPopController.tryPopFragments(eq(2), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
 
         // When
-        val result = unlimitedTabHistoryController!!.popFragments(2, mockTransactionOptions)
+        val result = unlimitedTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -110,25 +110,25 @@ class UnlimitedTabHistoryControllerTest {
 
         // Navigating ahead through tabs
         for (i in 1..5) {
-            unlimitedTabHistoryController!!.switchTab(i)
+            unlimitedTabHistoryController.switchTab(i)
         }
 
         // Navigating backwards through tabs
         for (i in 5 downTo 1) {
-            unlimitedTabHistoryController!!.switchTab(i)
+            unlimitedTabHistoryController.switchTab(i)
         }
 
         // Every tab contains 1 item
         run {
             var i = 7
             while (i < 16) {
-                `when`(mockFragNavPopController!!.tryPopFragments(eq(i), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
+                `when`(mockFragNavPopController.tryPopFragments(eq(i), eq<FragNavTransactionOptions>(mockTransactionOptions))).thenReturn(1)
                 i += 2
             }
         }
 
         // When
-        val result = unlimitedTabHistoryController!!.popFragments(15, mockTransactionOptions)
+        val result = unlimitedTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
         assertTrue(result)
@@ -151,19 +151,19 @@ class UnlimitedTabHistoryControllerTest {
 
         // Navigating ahead through tabs
         for (i in 1..5) {
-            unlimitedTabHistoryController!!.switchTab(i)
+            unlimitedTabHistoryController.switchTab(i)
         }
 
         // Navigating backwards through tabs
         for (i in 5 downTo 1) {
-            unlimitedTabHistoryController!!.switchTab(i)
+            unlimitedTabHistoryController.switchTab(i)
         }
 
         // When
         for (i in 0..8) {
-            assertTrue(unlimitedTabHistoryController!!.popFragments(1, mockTransactionOptions))
+            assertTrue(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
         }
-        assertFalse(unlimitedTabHistoryController!!.popFragments(1, mockTransactionOptions))
+        assertFalse(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
 
         // Then
         val argumentCaptor = ArgumentCaptor.forClass(Int::class.java)
@@ -183,14 +183,14 @@ class UnlimitedTabHistoryControllerTest {
     fun testHistoryIsSavedAndRestoredWhenSaveCalledNewInstanceCreatedRestoreCalled() {
         // Given
         for (i in 5 downTo 1) {
-            unlimitedTabHistoryController!!.switchTab(i)
+            unlimitedTabHistoryController.switchTab(i)
         }
 
         // When
-        unlimitedTabHistoryController!!.onSaveInstanceState(mockBundle!!)
+        unlimitedTabHistoryController.onSaveInstanceState(mockBundle)
         val newUniqueTabHistoryController = UnlimitedTabHistoryController(
-                mockFragNavPopController!!,
-                mockFragNavSwitchController!!)
+                mockFragNavPopController,
+                mockFragNavSwitchController)
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {


### PR DESCRIPTION
No need to maintain a stack of the fragments when we can just have a stack of the tags. The fragment manager maintains the actual instance of the fragments.