### PR TITLE
Minor changes in builder and fixing Default Transaction Options usage

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/Builder.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/Builder.kt
@@ -12,7 +12,7 @@ class Builder(private val savedInstanceState: Bundle?, val fragmentManager: Frag
     internal var transactionListener: FragNavController.TransactionListener? = null
     internal var defaultTransactionOptions: FragNavTransactionOptions? = null
     internal var numberOfTabs = 0
-    internal val rootFragments: MutableList<Fragment> = mutableListOf()
+    internal var rootFragments: List<Fragment>? = null
 
     @FragNavController.TabIndex
     internal var selectedTabIndex = FragNavController.TAB1
@@ -49,7 +49,10 @@ class Builder(private val savedInstanceState: Bundle?, val fragmentManager: Frag
      * transactions
      */
     fun rootFragments(rootFragments: List<Fragment>): Builder {
-        this.rootFragments.addAll(rootFragments)
+        if (rootFragmentListener != null) {
+            throw IllegalStateException("Root fragments and root fragment listener can not be set the same time")
+        }
+        this.rootFragments = rootFragments
         numberOfTabs = rootFragments.size
         if (numberOfTabs > FragNavController.MAX_NUM_TABS) {
             throw IllegalArgumentException("Number of root fragments cannot be greater than " + FragNavController.MAX_NUM_TABS)
@@ -70,6 +73,9 @@ class Builder(private val savedInstanceState: Bundle?, val fragmentManager: Frag
      * @param numberOfTabs         the number of tabs that will be switched between
      */
     fun rootFragmentListener(rootFragmentListener: FragNavController.RootFragmentListener, numberOfTabs: Int): Builder {
+        if (rootFragments != null) {
+            throw IllegalStateException("Root fragment listener and root fragments can not be set the same time")
+        }
         this.rootFragmentListener = rootFragmentListener
         this.numberOfTabs = numberOfTabs
         if (this.numberOfTabs > FragNavController.MAX_NUM_TABS) {
@@ -138,7 +144,7 @@ class Builder(private val savedInstanceState: Bundle?, val fragmentManager: Frag
     }
 
     fun build(): FragNavController {
-        if (rootFragmentListener == null && rootFragments.isEmpty()) {
+        if (rootFragmentListener == null && rootFragments == null) {
             throw IndexOutOfBoundsException("Either a root fragment(s) needs to be set, or a fragment listener")
         }
         return FragNavController(this, savedInstanceState)

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -171,6 +171,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
         if (currentStackIndex > fragmentStacksTags.size) {
             throw IndexOutOfBoundsException("Starting index cannot be larger than the number of stacks")
         }
+        fragNavTabHistoryController.switchTab(index)
 
         currentStackIndex = index
         clearFragmentManager()

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -63,14 +63,15 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
             else -> CurrentTabHistoryController(fragNavPopController)
         }
 
+        val initialRootFragments = builder.rootFragments
+        if (initialRootFragments != null) {
+            rootFragments.addAll(initialRootFragments)
+        }
+
         //Attempt to restore from bundle, if not, initialize
         if (!restoreFromBundle(savedInstanceState)) {
             for (i in 0 until builder.numberOfTabs) {
                 fragmentStacksTags.add(Stack())
-            }
-            val initialRootFragments = builder.rootFragments
-            if (initialRootFragments != null) {
-                rootFragments.addAll(initialRootFragments)
             }
 
             initialize(currentStackIndex)
@@ -408,7 +409,7 @@ class FragNavController internal constructor(builder: Builder, savedInstanceStat
             if (fragment != null) {
                 commitTransaction(ft, transactionOptions)
             } else {
-                if (!fragmentStack.isEmpty()) {
+                if (fragmentStack.isNotEmpty()) {
                     val fragmentTag = fragmentStack.peek()
                     fragment = fragmentManger.findFragmentByTag(fragmentTag)
                     ft.add(containerId, fragment, fragmentTag)


### PR DESCRIPTION
Added guard against using both root fragment provider methods
Fixed default transaction options to be used even for commitAllowingStateloss
Fixing crash when trying to use prebuilt root fragments after rotation