### PR TITLE
Fixed popping animations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ install:
   - echo yes | sdkmanager "extras;google;m2repository"
 
 script:
-  - ./gradlew testDebugUnitTest coveralls
+  - ./gradlew jacocoTestReportDebug coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ install:
   - echo yes | sdkmanager "extras;google;m2repository"
 
 script:
-  - ./gradlew connectedAndroidTest coveralls
+  - ./gradlew testDebugUnitTest coveralls

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,10 +27,8 @@ repositories {
 
 dependencies {
     implementation project(':frag-nav')
-    // implementation 'com.ncapdevi:frag-nav:2.2.1'
-    implementation project(':frag-nav')
-    implementation "com.android.support:design:$rootProject.ext.supportVersion"
-    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportVersion"
+    implementation "com.google.android.material:material:$rootProject.ext.supportVersion"
+    implementation "androidx.appcompat:appcompat:1.0.2"
     implementation "com.roughike:bottom-bar:2.3.1"
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
@@ -1,8 +1,8 @@
 package com.ncapdevi.sample.activities
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v7.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.MenuItem
 import com.ncapdevi.fragnav.FragNavController
@@ -23,7 +23,7 @@ class BottomTabsActivity : AppCompatActivity(), BaseFragment.FragmentNavigation,
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(com.ncapdevi.sample.R.layout.activity_bottom_tabs)
+        setContentView(R.layout.activity_bottom_tabs)
 
          bottomBar = findViewById(R.id.bottomBar)
 
@@ -37,6 +37,7 @@ class BottomTabsActivity : AppCompatActivity(), BaseFragment.FragmentNavigation,
                 }
             }
 
+            defaultTransactionOptions = FragNavTransactionOptions.newBuilder().customAnimations(R.anim.slide_in_from_right, R.anim.slide_out_to_left, R.anim.slide_in_from_left, R.anim.slide_out_to_right).build()
             fragmentHideStrategy = FragNavController.DETACH_ON_NAVIGATE_HIDE_ON_SWITCH
 
             navigationStrategy = UniqueTabHistoryStrategy(object : FragNavSwitchController {

--- a/app/src/main/java/com/ncapdevi/sample/activities/MainActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/MainActivity.kt
@@ -2,7 +2,7 @@ package com.ncapdevi.sample.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.widget.Button
 import com.ncapdevi.fragnav.FragNavController

--- a/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
@@ -1,13 +1,13 @@
 package com.ncapdevi.sample.activities
 
 import android.os.Bundle
-import android.support.design.widget.NavigationView
-import android.support.v4.app.Fragment
-import android.support.v4.view.GravityCompat
-import android.support.v4.widget.DrawerLayout
-import android.support.v7.app.ActionBarDrawerToggle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.Toolbar
+import com.google.android.material.navigation.NavigationView
+import androidx.fragment.app.Fragment
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import android.view.MenuItem
 import com.ncapdevi.fragnav.FragNavController
 import com.ncapdevi.fragnav.FragNavTransactionOptions

--- a/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
@@ -2,7 +2,7 @@ package com.ncapdevi.sample.fragments
 
 import android.content.Context
 import android.os.Bundle
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/res/layout/activity_nav_drawer.xml
+++ b/app/src/main/res/layout/activity_nav_drawer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout
+<androidx.drawerlayout.widget.DrawerLayout
     android:id="@+id/drawer_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/nav_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -23,4 +23,4 @@
         app:headerLayout="@layout/nav_header_nav_drawer"
         app:menu="@menu/activity_nav_drawer_drawer"/>
 
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/app_bar_nav_drawer.xml
+++ b/app/src/main/res/layout/app_bar_nav_drawer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,19 +8,19 @@
     android:fitsSystemWindows="true"
     tools:context="com.ncapdevi.sample.activities.NavDrawerActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_nav_drawer"/>
 
@@ -29,4 +29,4 @@
                  android:id="@+id/container"/>
 
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -11,7 +11,6 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
-
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar"/>
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light"/>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.10'
+    ext.spek_version = '2.0.0-rc.1'
     repositories {
         jcenter()
         google()
@@ -8,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.0.32"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.1.1"
     }
 }
 
@@ -33,7 +34,7 @@ ext {
     // App dependencies
 
     junitVersion = '4.12'
-    supportVersion = '27.1.1'
+    supportVersion = '1.0.0'
     buildToolsVersion = '28.0.3'
     minSdkVersion = 14
     targetSdkVersion = 28

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.1.1"
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.13.0"
     }
 }
 

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven'
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: "de.mannodermaus.android-junit5"
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 ext {
     libraryVersionCode = 27
@@ -191,11 +192,11 @@ bintray {
 }
 
 coveralls {
-    jacocoReportPath = "${buildDir}/reports/coverage/debug/report.xml"
+    jacocoReportPath = "${buildDir}/reports/jacoco/debug/jacoco.xml"
 }
 
 tasks.coveralls {
-    dependsOn 'testDebugUnitTest'
+    dependsOn 'jacocoTestReportDebug'
     onlyIf { System.env.'CI' }
 }
 task createPom {

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -195,7 +195,7 @@ coveralls {
 }
 
 tasks.coveralls {
-    dependsOn 'connectedAndroidTest'
+    dependsOn 'testDebugUnitTest'
     onlyIf { System.env.'CI' }
 }
 task createPom {

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.2"
+    id "com.jfrog.bintray" version "1.8.4"
     id "com.github.dcendents.android-maven" version "2.1"
-    id 'com.github.kt3k.coveralls' version '2.5.0-x'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
 apply plugin: 'com.android.library'
@@ -41,7 +41,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
-    lintOptions{
+    lintOptions {
         abortOnError false
     }
     defaultConfig {
@@ -65,15 +65,9 @@ android {
             includeAndroidResources = true
         }
         junitPlatform {
-            // The JUnit Jupiter dependency version to use
-            jupiterVersion "5.2.0"
-
-            // The JUnit Vintage Engine dependency version to use
-            vintageVersion "5.2.0"
-
             filters {
                 engines {
-                    include 'spek'
+                    include 'spek2'
                 }
             }
         }
@@ -83,29 +77,20 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "com.android.support:support-fragment:$rootProject.ext.supportVersion"
-    implementation "com.android.support:support-annotations:$rootProject.ext.supportVersion"
+    implementation "androidx.fragment:fragment:$rootProject.ext.supportVersion"
+    implementation "androidx.annotation:annotation:$rootProject.ext.supportVersion"
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
-    testImplementation "org.mockito:mockito-core:2.19.0"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-alpha04"
-    testImplementation "org.robolectric:robolectric:3.8"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0"
+    testImplementation "org.robolectric:robolectric:4.0.2"
 
-    testImplementation 'org.amshove.kluent:kluent-android:1.38'
+    testImplementation 'org.amshove.kluent:kluent-android:1.42'
 
     // Spek
 
+    testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
+    testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    testImplementation ('org.jetbrains.spek:spek-api:1.1.5') {
-        exclude group: 'org.jetbrains.kotlin'
-    }
-    testImplementation ('org.jetbrains.spek:spek-junit-platform-engine:1.1.5') {
-        exclude group: 'org.junit.platform'
-        exclude group: 'org.jetbrains.kotlin'
-    }
-
-    testCompileOnly junit5.unitTestsRuntime()
-    testImplementation junit5.unitTests()
 }
 
 group = publishedGroupId                               // Maven Group ID for the artifact
@@ -175,7 +160,7 @@ if (project.hasProperty("android")) { // Android libraries
 }*/
 
 artifacts {
-   // archives javadocJar
+    // archives javadocJar
     archives sourcesJar
 }
 

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
@@ -1,9 +1,8 @@
 package com.ncapdevi.fragnav
 
-import android.support.annotation.AnimRes
-import android.support.annotation.StyleRes
-import android.support.v4.app.FragmentTransaction
-import android.support.v4.util.Pair
+import androidx.annotation.AnimRes
+import androidx.annotation.StyleRes
+import androidx.fragment.app.FragmentTransaction
 import android.view.View
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
@@ -1,7 +1,7 @@
 package com.ncapdevi.fragnav.tabhistory
 
 import android.os.Bundle
-import android.support.annotation.IntDef
+import androidx.annotation.IntDef
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 
 interface FragNavTabHistoryController {

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerTest.kt
@@ -1,8 +1,8 @@
 package com.ncapdevi.fragnav
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import android.widget.FrameLayout
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -60,7 +60,7 @@ class FragNavControllerTest : FragNavController.TransactionListener {
         mFragNavController.initialize(savedInstanceState = bundle)
 
         Assert.assertEquals(FragNavController.TAB2.toLong(), mFragNavController.currentStackIndex.toLong())
-        Assert.assertEquals(3, mFragNavController.currentStack!!.size.toLong())
+        Assert.assertEquals(4, mFragNavController.currentStack!!.size.toLong())
         Assert.assertEquals(currentFragment, mFragNavController.currentFrag)
     }
 

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
@@ -1,9 +1,9 @@
 package com.ncapdevi.fragnav
 
-import android.support.annotation.AnimRes
-import android.support.annotation.StyleRes
-import android.support.v4.app.FragmentTransaction
-import android.support.v4.util.Pair
+import androidx.annotation.AnimRes
+import androidx.annotation.StyleRes
+import androidx.fragment.app.FragmentTransaction
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,8 +36,8 @@ class FragNavTransactionOptionsTest {
             .transition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .customAnimations(enterAnim, exitAnim, popEnterAnim, popExitAnim)
             .transitionStyle(transitionStyle)
-            .addSharedElement(Pair(null, "test"))
-            .addSharedElement(Pair(null, "test2")).build()
+            .addSharedElement(Pair(mock(), "test"))
+            .addSharedElement(Pair(mock(), "test2")).build()
 
         assertTrue(breadCrumbShortTitle.equals(fragNavTransactionOptions.breadCrumbShortTitle, ignoreCase = true))
         assertTrue(breadCrumbTitle.equals(fragNavTransactionOptions.breadCrumbTitle, ignoreCase = true))

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
When migrating to 3.0 I've made the mistake of using the built in pop
animation support for fragment transactions but our pops are not really
pops as fragment manager usually interpret it. Hence I've reverted the
change.

* Introduced androidX and fixed issues
* Updated library dependencies
* Fixed failing test case
* Migrated to Spek 2
* Fixed popping animations
* Fixed Animation weirdness with eager initialization
* Made Travis to run unit tests
* Coverall shows real coverage

[#176][ #161]

@ncapdevi please review if you'll have time. Great job on 3.0 btw