### PR TITLE
Trigger transaction listener when restoring tab from bundle

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -839,6 +839,8 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
                 // We cannot use switchTab, because switchTab removes fragment, but we don't want it
                 currentStackIndex = selectedTabIndex
                 fragNavTabHistoryController.switchTab(selectedTabIndex)
+
+                transactionListener?.onTabTransaction(mCurrentFrag, selectedTabIndex)
             }
 
             //Successfully restored state


### PR DESCRIPTION
`FragNavController.restoreFromBundle` attempts to re-select the
previously selected tab when restoring its state from a `Bundle`, but
was not notifying the `TransactionListener` (if one was set).