### PR TITLE
Adding reordering option to FragNavTransactionOptions

### DIFF
--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment
 import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.MenuItem
+import android.view.View
 import com.ncapdevi.fragnav.FragNavController
 import com.ncapdevi.fragnav.FragNavLogger
 import com.ncapdevi.fragnav.FragNavSwitchController
@@ -79,8 +80,15 @@ class BottomTabsActivity : AppCompatActivity(), BaseFragment.FragmentNavigation,
 
     }
 
-    override fun pushFragment(fragment: Fragment) {
-        fragNavController.pushFragment(fragment)
+    override fun pushFragment(fragment: Fragment, sharedElementList: List<Pair<View, String>>?) {
+        val options = FragNavTransactionOptions.newBuilder()
+        options.reordering = true
+        sharedElementList?.let {
+            it.forEach { pair ->
+                options.addSharedElement(pair)
+            }
+        }
+        fragNavController.pushFragment(fragment, options.build())
 
     }
 

--- a/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import android.view.MenuItem
+import android.view.View
 import com.ncapdevi.fragnav.FragNavController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.ncapdevi.sample.R
@@ -95,7 +96,7 @@ class NavDrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         return true
     }
 
-    override fun pushFragment(fragment: Fragment) {
+    override fun pushFragment(fragment: Fragment, sharedList: List<Pair<View, String>>?) {
         fragNavController.pushFragment(fragment)
     }
 }

--- a/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
@@ -42,7 +42,7 @@ open class BaseFragment : Fragment() {
     }
 
     interface FragmentNavigation {
-        fun pushFragment(fragment: Fragment)
+        fun pushFragment(fragment: Fragment, sharedElementList: List<Pair<View, String>>?= null)
     }
 
     companion object {

--- a/app/src/main/java/com/ncapdevi/sample/fragments/FavoritesFragment.kt
+++ b/app/src/main/java/com/ncapdevi/sample/fragments/FavoritesFragment.kt
@@ -1,8 +1,13 @@
 package com.ncapdevi.sample.fragments
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Bundle
+import android.transition.TransitionInflater
 import android.view.View
+import android.widget.CheckBox
+import android.widget.EditText
+import com.ncapdevi.sample.R
 
 /**
  * Created by niccapdevila on 3/26/16.
@@ -12,8 +17,29 @@ class FavoritesFragment : BaseFragment() {
     @SuppressLint("SetTextI18n")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(
+                        android.R.transition.fade
+                )
+            }
+        }
+
+        val et = view.findViewById<EditText>(R.id.edit_text)
+        val cb = view.findViewById<CheckBox>(R.id.checkbox)
+
+        val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            listOf<Pair<View, String>>(
+                    Pair(et, et.transitionName),
+                    Pair(cb, cb.transitionName)
+            )
+        } else {
+            listOf()
+        }
+
         btn.setOnClickListener {
-            mFragmentNavigation.pushFragment(FavoritesFragment.newInstance(mInt + 1))
+            mFragmentNavigation.pushFragment(newInstance(mInt + 1), list)
         }
         btn.text = """${javaClass.simpleName} $mInt"""
     }

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -13,12 +13,15 @@
         android:layout_height="wrap_content" />
 
     <EditText
+        android:id="@+id/edit_text"
+        android:transitionName="1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         tools:ignore="LabelFor"
         android:inputType="text" />
     <CheckBox
         android:id="@+id/checkbox"
+        android:transitionName="2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Example to show restored state"/>

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -684,6 +684,8 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
                     options.breadCrumbTitle != null -> setBreadCrumbTitle(options.breadCrumbTitle)
                     options.breadCrumbShortTitle != null -> setBreadCrumbShortTitle(options.breadCrumbShortTitle)
                 }
+
+                setReorderingAllowed(options.reordering)
             }
         }
     }

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
@@ -23,7 +23,7 @@ class FragNavTransactionOptions private constructor(builder: Builder) {
     val breadCrumbTitle: String? = builder.breadCrumbTitle
     val breadCrumbShortTitle: String? = builder.breadCrumbShortTitle
     val allowStateLoss: Boolean = builder.allowStateLoss
-
+    val reordering: Boolean = builder.reordering
 
     class Builder {
         var sharedElements: MutableList<Pair<View, String>> = mutableListOf()
@@ -36,6 +36,7 @@ class FragNavTransactionOptions private constructor(builder: Builder) {
         var breadCrumbTitle: String? = null
         var breadCrumbShortTitle: String? = null
         var allowStateLoss = false
+        var reordering = false
 
         fun addSharedElement(element: Pair<View, String>): Builder {
             sharedElements.add(element)
@@ -82,6 +83,11 @@ class FragNavTransactionOptions private constructor(builder: Builder) {
 
         fun allowStateLoss(allow: Boolean): Builder {
             allowStateLoss = allow
+            return this
+        }
+
+        fun allowReordering(reorder: Boolean): Builder {
+            reordering = reorder
             return this
         }
 


### PR DESCRIPTION
Shared element transition requires `reordering` to be `true`.

Edited `FavoritesFragment` to see the effect using `reordering=true` and shared element transition. You can notice the edit text has a fading transition when a new fragment is pushed. The same effect will not appear if `reordering=false`.