### PR TITLE
Support pushing a Fragment using Fragment class

### DIFF
--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -78,7 +78,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.fragment:fragment:1.0.0"
+    implementation "androidx.fragment:fragment:1.2.5"
     implementation "androidx.annotation:annotation:1.0.2"
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
@@ -168,7 +168,7 @@ class FakeFragmentTransaction(private val parent: FakeFragmentManager) {
 
     fun create(): FragmentTransaction {
         return mock {
-            on { add(any(), any(), any()) } doAnswer { invocationOnMock ->
+            on { add(any<Int>(), any<Fragment>(), any<String>()) } doAnswer { invocationOnMock ->
                 pendingActions.add(Add(invocationOnMock.getArgument<Fragment>(1), invocationOnMock.getArgument<String>(2)))
                 this.mock
             }

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerTest.kt
@@ -1,9 +1,9 @@
 package com.ncapdevi.fragnav
 
 import android.os.Bundle
+import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import android.widget.FrameLayout
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -14,8 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import java.util.*
-
+import java.util.ArrayList
 
 /**
  * Created by niccapdevila on 2/10/18.
@@ -189,6 +188,41 @@ class FragNavControllerTest : FragNavController.TransactionListener {
         Assert.assertTrue(mFragNavController.currentStack!!.size == 1)
         Assert.assertTrue(mFragNavController.isRootFragment)
     }
+
+    @Test
+    fun pushPopClearWithFragmentClass() {
+        mFragNavController = FragNavController(fragmentManager, frameLayout.id).apply {
+            transactionListener = this@FragNavControllerTest
+            rootFragments = listOf(Fragment())
+        }
+
+        mFragNavController.initialize()
+
+        Assert.assertEquals(FragNavController.TAB1.toLong(), mFragNavController.currentStackIndex.toLong())
+        Assert.assertNotNull(mFragNavController.currentStack)
+
+        var size = mFragNavController.currentStack!!.size
+
+        val bundle = Bundle()
+
+        mFragNavController.pushFragment(Fragment::class.java, bundle)
+        Assert.assertTrue(mFragNavController.currentStack!!.size == ++size)
+
+        mFragNavController.pushFragment(TestFragment::class.java, bundle)
+        Assert.assertTrue(mFragNavController.currentStack!!.size == ++size)
+
+        mFragNavController.pushFragment(Fragment())
+        Assert.assertTrue(mFragNavController.currentStack!!.size == ++size)
+
+        mFragNavController.popFragment()
+        Assert.assertTrue(mFragNavController.currentStack!!.size == --size)
+
+        mFragNavController.clearStack()
+        Assert.assertTrue(mFragNavController.currentStack!!.size == 1)
+        Assert.assertTrue(mFragNavController.isRootFragment)
+    }
+
+    class TestFragment: Fragment()
 
     @Test
     fun testTabStackClear() {


### PR DESCRIPTION
- The current `FragmentController#pushFragment` method allows only pushing passing a Fragment instance. A more recent version of the AndroidX Fragment lib supports adding/replacing Fragments by their classes so that the `FragmentFactory` is used. This allow developers to control how fragments are instantiated.
- This change introduces an additional `FragmentController#pushFragment` that receives the Fragment class and the arguments so that developers can also use `FragmentFactory`